### PR TITLE
chore: improve gallery responsiveness for screens with widths less than 768 width

### DIFF
--- a/app/css/user-gallery.scss
+++ b/app/css/user-gallery.scss
@@ -3,12 +3,12 @@
 
   > .items {
     display: grid;
-    grid-template-columns: 1fr;
+    grid-template-columns: 1fr 1fr 1fr;
     grid-template-rows: auto;
     grid-gap: 16px;
 
-    @media screen and (min-width: 768.1px) {
-      grid-template-columns: 1fr 1fr 1fr;
+    @media screen and (max-width: 480px) {
+      grid-template-columns: 1fr;
     }
   }
 

--- a/app/css/user-gallery.scss
+++ b/app/css/user-gallery.scss
@@ -1,14 +1,18 @@
 .user-gallery {
-  width: 100%;
-
   > .items {
     display: grid;
-    grid-template-columns: 1fr 1fr 1fr;
+    grid-template-columns: 1fr;
     grid-template-rows: auto;
     grid-gap: 16px;
+    white-space: nowrap;
 
-    @media screen and (max-width: 480px) {
-      grid-template-columns: 1fr;
+    @media screen and (min-width: 481.1px) {
+      grid-template-columns: 1fr 1fr;
+    }
+
+    @media screen and (min-width: 768.1px) {
+      white-space: normal;
+      grid-template-columns: 1fr 1fr 1fr;
     }
   }
 


### PR DESCRIPTION
### Issue
Fitting Issues for screen with less than 768.1 width. Namely:
- Tablet: 481px to 768px
- Mobile Phones: 0px to 480px

### Description
This pull request specifically addresses the fitting issues encountered on screens with a width less than 768.1 pixels. It does keep the current responsiveness settings for screens with width 768.1 and larger.

### Changes Made
Added a nowrap to address the text fitting issues and a double column for the tablet breakpoint.

### Screenshots 
Mobile Breakpoint (0px to 480px)
<img width="478" alt="Screenshot 2024-01-19 at 1 43 51 AM" src="https://github.com/AdyCastEX/frontend_test/assets/23498730/2c96b756-628d-47cc-adf5-b99319b3d2d9">

Tablet Breakpoint (481px to 768px)
<img width="470" alt="Screenshot 2024-01-19 at 1 44 09 AM" src="https://github.com/AdyCastEX/frontend_test/assets/23498730/55e8d973-bdf5-4934-8bb7-960cb64812e2">

Large Tablets and Desktop Breakpoint (768.1px and larger)
<img width="989" alt="Screenshot 2024-01-19 at 1 42 33 AM" src="https://github.com/AdyCastEX/frontend_test/assets/23498730/8d0fc027-5f84-4120-98cf-81a745e3b994">
