### PR TITLE
fix: user info display issues caused by className typos

### DIFF
--- a/app/css/user-panel.scss
+++ b/app/css/user-panel.scss
@@ -1,7 +1,7 @@
 .user-panel {
   display: flex;
   flex-flow: column nowrap;
-  padding: 16px;
+  padding: 24px;
 
   > .header {
     flex: 0 0 48px;

--- a/app/gallery.tsx
+++ b/app/gallery.tsx
@@ -93,13 +93,13 @@ const Gallery = ({ users }: GalleryProps) => {
                   </div>
                   <div className="field">
                     <FaLocationDot className="icon" />
-                    <div className="data">{`${selectedUser.address.street}, ${selectedUser.address.suite}, ${selectedUser.address.city}`}</div>
+                    <div className="value">{`${selectedUser.address.street}, ${selectedUser.address.suite}, ${selectedUser.address.city}`}</div>
                   </div>
                   <div className="field">
                     <FaPhone className="icon" />
                     <div className="value">{selectedUser.phone}</div>
                   </div>
-                  <div className="fields">
+                  <div className="field">
                     <FaEnvelope className="icon" />
                     <div className="value">{selectedUser.email}</div>
                   </div>


### PR DESCRIPTION
### Issue
Information in the user info is not properly displayed due to classNames typo. 
- User Address
- User Email

### Description
This pull request addresses the issue where certain information was not displayed properly due to a typo in the classNames. 

### Changes Made
- Corrected the typos in classNames to ensure correct display.

### Screenshots 
Before
<img width="483" alt="Screenshot 2024-01-19 at 12 06 56 AM" src="https://github.com/AdyCastEX/frontend_test/assets/23498730/9db9c80c-fa2f-4ec7-9754-c288bfdb596f">
After
<img width="486" alt="Screenshot 2024-01-19 at 12 06 08 AM" src="https://github.com/AdyCastEX/frontend_test/assets/23498730/01fc814f-b6ea-45ca-8942-b72f3402fc07">